### PR TITLE
fix(kyc)!: change change_service_admin's payload type

### DIFF
--- a/services/kyc/src/lib.rs
+++ b/services/kyc/src/lib.rs
@@ -7,9 +7,9 @@ use error::ServiceError;
 
 use expression::traits::ExpressionDataFeed;
 use types::{
-    ChangeOrgAdmin, ChangeOrgApproved, EvalUserTagExpression, FixedTagList, Genesis, GetUserTags,
-    KycOrgInfo, NewOrgEvent, OrgName, RegisterNewOrg, TagName, UpdateOrgSupportTags,
-    UpdateUserTags, Validate,
+    ChangeOrgAdmin, ChangeOrgApproved, ChangeServiceAdmin, EvalUserTagExpression, FixedTagList,
+    Genesis, GetUserTags, KycOrgInfo, NewOrgEvent, OrgName, RegisterNewOrg, TagName,
+    UpdateOrgSupportTags, UpdateUserTags, Validate,
 };
 
 use binding_macro::{cycles, genesis, service};
@@ -277,12 +277,16 @@ impl<SDK: ServiceSDK> KycService<SDK> {
     fn change_service_admin(
         &mut self,
         ctx: ServiceContext,
-        new_admin: Address,
+        payload: ChangeServiceAdmin,
     ) -> ServiceResponse<()> {
+        if let Err(e) = payload.validate() {
+            return e.into();
+        }
+
         require_service_admin!(self, &ctx);
 
         self.sdk
-            .set_value(KYC_SERVICE_ADMIN_KEY.to_owned(), new_admin);
+            .set_value(KYC_SERVICE_ADMIN_KEY.to_owned(), payload.new_admin);
         ServiceResponse::from_succeed(())
     }
 

--- a/services/kyc/src/tests.rs
+++ b/services/kyc/src/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
     types::{
-        ChangeOrgAdmin, ChangeOrgApproved, EvalUserTagExpression, FixedTagList, Genesis,
-        GetUserTags, NewOrgEvent, OrgName, RegisterNewOrg, TagName, UpdateUserTags, Validate,
+        ChangeOrgAdmin, ChangeOrgApproved, ChangeServiceAdmin, EvalUserTagExpression, FixedTagList,
+        Genesis, GetUserTags, NewOrgEvent, OrgName, RegisterNewOrg, TagName, UpdateUserTags,
+        Validate,
     },
     ExpressionDataFeed, KycService, ServiceError, UpdateOrgSupportTags,
 };
@@ -81,7 +82,9 @@ fn should_correctly_init_genesis() {
 
     // Change service admin
     let ctx = mock_context(TestService::service_admin());
-    let changed = service.change_service_admin(ctx.clone(), TestService::chen_ten());
+    let changed = service.change_service_admin(ctx.clone(), ChangeServiceAdmin {
+        new_admin: TestService::chen_ten(),
+    });
     assert!(!changed.is_error());
 
     // Change org admin

--- a/services/kyc/src/types.rs
+++ b/services/kyc/src/types.rs
@@ -600,3 +600,18 @@ impl Validate for ChangeOrgAdmin {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChangeServiceAdmin {
+    pub new_admin: Address,
+}
+
+impl Validate for ChangeServiceAdmin {
+    fn validate(&self) -> Result<(), ServiceError> {
+        if self.new_admin == Address::default() {
+            Err(BadPayload("invalid admin address").into())
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
**What type of PR is this?**

fix(kyc)!: change change_service_admin's payload type

**What this PR does / why we need it**:

Usign wrapper data type to avoid potential JSON ser/de failure in muta js sdk.