### PR TITLE
fix: change clap version to env!("CARGO_PKG_VERSION")

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 dependencies = [
  "async-trait",
  "binding-macro",
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "governance"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 dependencies = [
- "asset 0.4.0-beta2",
+ "asset 0.4.0-Alpha",
  "async-trait",
  "binding-macro",
  "byteorder",
@@ -1569,7 +1569,7 @@ dependencies = [
  "framework",
  "hex",
  "lazy_static",
- "metadata 0.4.0-beta2",
+ "metadata 0.4.0-Alpha",
  "muta",
  "muta-codec-derive",
  "muta-protocol",
@@ -1726,10 +1726,10 @@ dependencies = [
 
 [[package]]
 name = "huobi-chain"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 dependencies = [
  "admission_control",
- "asset 0.4.0-beta2",
+ "asset 0.4.0-Alpha",
  "async-trait",
  "authorization",
  "bytes 0.5.5",
@@ -1741,7 +1741,7 @@ dependencies = [
  "hex",
  "kyc",
  "lazy_static",
- "metadata 0.4.0-beta2",
+ "metadata 0.4.0-Alpha",
  "multi-signature",
  "muta",
  "muta-codec-derive",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "metadata"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 dependencies = [
  "async-trait",
  "binding-macro",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 dependencies = [
  "async-trait",
  "binding-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huobi-chain"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 

--- a/services/asset/Cargo.toml
+++ b/services/asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 

--- a/services/governance/Cargo.toml
+++ b/services/governance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "governance"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 

--- a/services/metadata/Cargo.toml
+++ b/services/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 

--- a/services/riscv/Cargo.toml
+++ b/services/riscv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.4.0-beta2"
+version = "0.4.0-Alpha"
 authors = ["Muta Dev <muta@nervos.org>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ impl ServiceMapping for DefaultServiceMapping {
 
 fn main() {
     let matches = clap::App::new("Huobi-chain")
-        .version("v0.3.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Muta Dev <muta@nervos.org>")
         .arg(
             clap::Arg::from_usage("-c --config=[FILE] 'a required file for the configuration'")


### PR DESCRIPTION
**What type of PR is this?**

 fix: change clap version to env!("CARGO_PKG_VERSION") and fix huobi-chain version

**What this PR does / why we need it**:

now clap will response -V / --version as same as cargo.toml/package/version